### PR TITLE
fix: noteFeed query and newNote mutation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js: 
-  - "12.13.1"
+  - "12.16.3"
 
 services:
   - mongodb

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Social note application",
   "main": "index.js",
   "engines": {
-    "node": "12.13.1"
+    "node": "12.16.3"
   },
   "scripts": {
     "preinstall": "yarn global add rimraf",

--- a/src/database/seed/index.js
+++ b/src/database/seed/index.js
@@ -20,7 +20,7 @@ const seed = async () => {
           });
       })
       .catch(() => {
-        logger.error('something is wrong');
+        logger.error('....something is wrong...');
         process.exit(0);
       });
   }, 1000);

--- a/src/graphql/resolvers/queries/note.js
+++ b/src/graphql/resolvers/queries/note.js
@@ -23,6 +23,8 @@ export const noteQueries = {
     // if the cursor is not provided, the query will fetch the latest ten notes
     // sorted by the latest based on _id
     let notes = await models.Note.find(cursorQuery)
+      .populate('author')
+      .populate('favoritedBy')
       .sort({ _id: -1 })
       .limit(limit + 1);
     // if the returned notes are greater than the limit

--- a/tests/e2e/note.e2e.test.js
+++ b/tests/e2e/note.e2e.test.js
@@ -120,6 +120,7 @@ describe('Note CRUD', () => {
   context('when a user sends a query to fetch all notes', () => {
     it('should return an array of notes', async () => {
       const res = await fetchAllNotes(baseUrl);
+
       res.body.should.have.property('data');
       res.body.data.should.have.property('notes');
       expect(res.body.data.notes).to.be.an('array');
@@ -256,7 +257,7 @@ describe('Note CRUD', () => {
   context('when a user sends a newNote mutation with a token that resolves to a non existant user', () => {
     before(async () => {
       await db.models.User.deleteOne({ _id: user._id });
-    })
+    });
     it('should throw an AuthenticationError', async () => {
       const res = await createNote(baseUrl,
         {


### PR DESCRIPTION
#### Decribe what this PR does

- implements fix for `noteFeed ` and `newNote`

#### Describe the tasks that support this PR

- populate `author` and `favoritedBy` fields on noteFeed query
- remove the unique constraint on note model
- add implementation to add to the user's notes array while creating a new note

#### Select the test categories recorded for this feature / fix

- [ ] unit tests

- [x] e2e tests

- [ ] integration tests

#### Outline the steps required to manually test your implementation

`Development Environment setup`

- clone the repository and run `cd Notedtly` to change to the project directory
- run `yarn install` command to install all the necessary dependencies and build the application
- run `yarn start` or `yarn dev` command to run the application

`Test Environment setup`

- run `yarn test:coverage` command to run all tests